### PR TITLE
Fixing unit tests by making sure that `smooch_user_id` values are unique per test

### DIFF
--- a/slash-response.test.js
+++ b/slash-response.test.js
@@ -225,17 +225,18 @@ test('reactivate Smooch bot', async () => {
   console['log'] = jest.fn(storeLog);
   const callback = jest.fn();
 
+  const id = buildRandomString();
   const email = buildRandomString() + '@test.com';
   const user = await callCheckApi('user', { email });
   const team = await callCheckApi('team', { email });
   const project = await callCheckApi('project', { team_id: team.data.dbid });
-  const annotation = await callCheckApi('dynamic_annotation', { set_action: 'deactivate', annotated_type: 'Project', annotated_id: project.data.dbid, annotation_type: 'smooch_user', fields: 'id,app_id,data', types: 'text,text,json', values: 'test,test,' + JSON.stringify({ phone: '123', app_name: 'Test' }) });
-  const key = 'slack_channel_smooch:' + config.redisPrefix + ':test';
+  const annotation = await callCheckApi('dynamic_annotation', { set_action: 'deactivate', annotated_type: 'Project', annotated_id: project.data.dbid, annotation_type: 'smooch_user', fields: 'id,app_id,data', types: 'text,text,json', values: id + ',test,' + JSON.stringify({ phone: '123', app_name: 'Test' }) });
+  const key = 'slack_channel_smooch:' + config.redisPrefix + ':' + id;
   const value = JSON.stringify({ mode: 'human', annotation_id: annotation.data.graphql_id });
   await redisSet(key, value);
   await sleep(3);
 
-  const data =  { body: { team_id: 'T12345ABC', channel_id: 'test' }, type: 'reactivateBot' };
+  const data =  { body: { team_id: 'T12345ABC', channel_id: id }, type: 'reactivateBot' };
   sr.handler(data, null, callback);
   await sleep(3);
 
@@ -258,17 +259,18 @@ test('send message to Smooch bot', async () => {
   console['log'] = jest.fn(storeLog);
   const callback = jest.fn();
 
+  const id = buildRandomString();
   const email = buildRandomString() + '@test.com';
   const user = await callCheckApi('user', { email });
   const team = await callCheckApi('team', { email });
   const project = await callCheckApi('project', { team_id: team.data.dbid });
-  const annotation = await callCheckApi('dynamic_annotation', { set_action: 'deactivate', annotated_type: 'Project', annotated_id: project.data.dbid, annotation_type: 'smooch_user', fields: 'id,app_id,data', types: 'text,text,json', values: 'test,test,' + JSON.stringify({ phone: '123', app_name: 'Test' }) });
-  const key = 'slack_channel_smooch:' + config.redisPrefix + ':test';
+  const annotation = await callCheckApi('dynamic_annotation', { set_action: 'deactivate', annotated_type: 'Project', annotated_id: project.data.dbid, annotation_type: 'smooch_user', fields: 'id,app_id,data', types: 'text,text,json', values: id + ',test,' + JSON.stringify({ phone: '123', app_name: 'Test' }) });
+  const key = 'slack_channel_smooch:' + config.redisPrefix + ':' + id;
   const value = JSON.stringify({ mode: 'human', annotation_id: annotation.data.graphql_id });
   await redisSet(key, value);
   await sleep(3);
 
-  const data = { body: { team_id: 'T12345ABC', channel_id: 'test' }, matches: ['bot send Test', 'Test'], type: 'sendBot' };
+  const data = { body: { team_id: 'T12345ABC', channel_id: id }, matches: ['bot send Test', 'Test'], type: 'sendBot' };
   sr.handler(data, null, callback);
   await sleep(3);
 


### PR DESCRIPTION
I captured the error in the Check API log when trying to run the tests locally:

```
postgres_1         | 2023-02-15 21:30:57.242 UTC [97] ERROR:  duplicate key value violates unique constraint "smooch_user_unique_id"
postgres_1         | 2023-02-15 21:30:57.242 UTC [97] DETAIL:  Key (value)=("test") already exists.
postgres_1         | 2023-02-15 21:30:57.242 UTC [97] STATEMENT:  INSERT INTO "dynamic_annotation_fields" ("annotation_id", "field_name", "annotation_type", "field_type", "value", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"
api_1              | 2023-02-15 21:30:57 +0000 Rack app ("GET /test/dynamic_annotationannotated_type=Project&annotated_id=55&annotation_type=smooch_user&fields=id,app_id,data&types=text,text,json&values=test,test,%7B%22identifier%22:%22db916ac85f6d89078db810ab2632eaaa%22,%22app_name%22:%22Test%22%7D" - (192.168.224.14)): #<ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "smooch_user_unique_id"
api_1              | DETAIL:  Key (value)=("test") already exists.
```

So, some Check Slack Bot tests started to fail after this change: meedan/check-api@6fc7b6e (CV2-2615). They started to fail because the same `smooch_user_id` is used across different tests. The fix here was to use different `smooch_user_id` values for each test.

Fixes CV2-2623.